### PR TITLE
Only run timeout tests for maintainer

### DIFF
--- a/t/012_timeout.t
+++ b/t/012_timeout.t
@@ -1,6 +1,21 @@
-use Test::More tests => 4;
+use Test::More;
 use strict;
 use Time::HiRes qw/gettimeofday tv_interval/;
+
+# These tests will only work without additional setup
+# People installing from CPAN are unlikely to have done this setup,
+# so only run these tests when run from git repository
+# or if environment variable indicates that tests are run by the maintainer
+if( -d '.git' or $ENV{IS_MAINTAINER} ) {
+	plan tests => 4;
+}
+else {
+	plan skip_all => 'Timeout tests require additional setup, only run for maintainer';
+}
+
+# On a GNU/Linux system, running the following command as root will generally
+# allow these tests to pass:
+# iptables -I OUTPUT --dst 127.0.1.2 -j DROP
 
 my $host = '127.0.1.2';
 $SIG{'PIPE'} = 'IGNORE';


### PR DESCRIPTION
This test will fail without additional setup which people just
installing from CPAN are unlikely to have done.  So, only run this when
doing tests from a git repository or an environment variable is set
indicating that maintainer tests should be used.

Also add a comment indicating one possible way to let these tests pass.
