### PR TITLE
Include sys/types.h

### DIFF
--- a/amqp.h
+++ b/amqp.h
@@ -1,6 +1,8 @@
 #ifndef librabbitmq_amqp_h
 #define librabbitmq_amqp_h
 
+#include <sys/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Needed on FreeBSD to get definition of uint64_t and related types.

The FreeBSD ports collection already had a similar patch.

Started looking into this while checking on the timeout test, but found that the module wouldn't compile there.  I've tested that it still compiles correctly on Linux and OS X.
