### PR TITLE
Bind with headers

### DIFF
--- a/RabbitMQ.pm
+++ b/RabbitMQ.pm
@@ -130,7 +130,7 @@ In array context, this method returns three items: queuename,
 the number of message waiting on the queue, and the number
 of consumers bound to the queue.
 
-=item queue_bind($channel, $queuename, $exchange, $routing_key)
+=item queue_bind($channel, $queuename, $exchange, $routing_key, $arguments)
 
 C<$channel> is a channel that has been opened with C<channel_open>.
 
@@ -138,10 +138,15 @@ C<$queuename> is a previously declared queue, C<$exchange> is a
 previously declared exchange, and C<$routing_key> is the routing
 key that will bind the specified queue to the specified exchange.
 
-=item queue_unbind($channel, $queuename, $exchange, $routing_key)
+C<$arguments> is an optional hash which will be passed to the server.  When
+binding to an exchange of type C<headers>, this can be used to only receive
+messages with the supplied header values.
 
-This is like the C<queue_bind> with respect to arguments.  This command
-unbinds the queue from the exchange.
+=item queue_unbind($channel, $queuename, $exchange, $routing_key, $arguments)
+
+This is like the C<queue_bind> with respect to arguments.  This command unbinds
+the queue from the exchange.  The C<$routing_key> and C<$arguments> must match
+the values supplied when the binding was created.
 
 =item publish($channel, $routing_key, $body, $options, $props)
 

--- a/RabbitMQ.xs
+++ b/RabbitMQ.xs
@@ -413,8 +413,12 @@ net_rabbitmq_queue_bind(conn, channel, queuename, exchange, bindingkey, args = N
     amqp_rpc_reply_t *amqp_rpc_reply;
     amqp_table_t arguments = AMQP_EMPTY_TABLE;
   CODE:
-    if(queuename == NULL || exchange == NULL || bindingkey == NULL)
-      Perl_croak(aTHX_ "queuename, exchange and bindingkey must all be specified");
+    if(queuename == NULL || exchange == NULL)
+      Perl_croak(aTHX_ "queuename and exchange must both be specified");
+    if(bindingkey == NULL && args == NULL)
+      Perl_croak(aTHX_ "bindingkey or args must be specified");
+    if(args)
+      hash_to_amqp_table(conn, args, &arguments);
     amqp_queue_bind(conn, channel, amqp_cstring_bytes(queuename),
                     amqp_cstring_bytes(exchange),
                     amqp_cstring_bytes(bindingkey),
@@ -434,8 +438,12 @@ net_rabbitmq_queue_unbind(conn, channel, queuename, exchange, bindingkey, args =
     amqp_rpc_reply_t *amqp_rpc_reply;
     amqp_table_t arguments = AMQP_EMPTY_TABLE;
   CODE:
-    if(queuename == NULL || exchange == NULL || bindingkey == NULL)
-      Perl_croak(aTHX_ "queuename, exchange and bindingkey must all be specified");
+    if(queuename == NULL || exchange == NULL)
+      Perl_croak(aTHX_ "queuename and exchange must both be specified");
+    if(bindingkey == NULL && args == NULL)
+      Perl_croak(aTHX_ "bindingkey or args must be specified");
+    if(args)
+      hash_to_amqp_table(conn, args, &arguments);
     amqp_queue_unbind(conn, channel, amqp_cstring_bytes(queuename),
                       amqp_cstring_bytes(exchange),
                     amqp_cstring_bytes(bindingkey),

--- a/t/014_bind_with_headers.t
+++ b/t/014_bind_with_headers.t
@@ -1,0 +1,55 @@
+use Test::More 'no_plan'; #  20;
+use strict;
+
+my $host = $ENV{'MQHOST'} || "dev.rabbitmq.com";
+
+use_ok('Net::RabbitMQ');
+
+my $mq = Net::RabbitMQ->new();
+ok($mq, "Created object");
+
+eval { $mq->connect($host, { user => "guest", password => "guest" }); };
+is($@, '', "connect");
+
+eval { $mq->channel_open(1); };
+is($@, '', "channel_open");
+
+my $delete = 1;
+my $key = 'key';
+my $queue;
+eval { $queue = $mq->queue_declare(1, "", { auto_delete => $delete } ); };
+is($@, '', "queue_declare");
+
+diag "Using queue $queue";
+
+my $exchange = "x-$queue";
+eval { $mq->exchange_declare( 1, $exchange, { exchange_type => 'headers', auto_delete => $delete } ); };
+is($@, '', "exchange_declare");
+
+my $headers = { foo => 'bar' };
+eval { $mq->queue_bind( 1, $queue, $exchange, $key, $headers ) };
+is( $@, '', "queue_bind" );
+
+# This message doesn't have the correct headers so will not be routed to the queue
+eval { $mq->publish( 1, $key, "Unroutable", { exchange => $exchange } ) };
+is( $@, '', "publish unroutable message" );
+
+eval { $mq->publish( 1, $key, "Routable", { exchange => $exchange }, { headers => $headers} ) };
+is( $@, '', "publish routable message" );
+
+eval { $mq->consume( 1, $queue ) };
+is( $@, '', "consume" );
+
+my $msg;
+eval { $msg = $mq->recv() };
+is( $@, '', "recv" );
+is( $msg->{body}, "Routable", "Got expected message" );
+
+SKIP: {
+	skip "Failed unbind closes channel", 1;
+	eval { $mq->queue_unbind( 1, $queue, $exchange, $key ) };
+	like( $@, qr/NOT_FOUND - no binding /, "Unbinding queue fails without specifying headers" );
+}
+
+eval { $mq->queue_unbind( 1, $queue, $exchange, $key, $headers ) };
+is( $@, '', "queue_unbind" );


### PR DESCRIPTION
This series add support for specifying arguments when binding a queue to an exchange.  If the exchange is of type "headers" this allows routing based on message headers.
