### PR TITLE
net_rabbitmq_get drops messages if  amqp_data_in_buffer is not ready

### DIFF
--- a/RabbitMQ.xs
+++ b/RabbitMQ.xs
@@ -657,11 +657,9 @@ net_rabbitmq_get(conn, channel, queuename, options = NULL)
       hv_store(hv, "exchange", strlen("exchange"), newSVpvn(ok->exchange.bytes, ok->exchange.len), 0);
       hv_store(hv, "routing_key", strlen("routing_key"), newSVpvn(ok->routing_key.bytes, ok->routing_key.len), 0);
       hv_store(hv, "message_count", strlen("message_count"), newSViv(ok->message_count), 0);
-      if(amqp_data_in_buffer(conn)) {
-        int rv;
-        rv = internal_recv(hv, conn, 1);
-        if(rv <= 0) Perl_croak(aTHX_ "Bad frame read.");
-      }
+      int rv;
+      rv = internal_recv(hv, conn, 1);
+      if(rv <= 0) Perl_croak(aTHX_ "Bad frame read.");
       RETVAL = (SV *)newRV_noinc((SV *)hv);
     }
     else


### PR DESCRIPTION
internally internal_recv uses amqp_data_in_buffer
correctly handling where large messages may not
be in the buffer yet. This patch skips the unneeded call
in net_rabbitmq_get.

internal_recv
   amqp_simple_wait_frame
     wait_frame_inner
       amqp_data_in_buffer
