### PR TITLE
bugfix for #79411 Connect with invalid password exits 

### DIFF
--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -381,18 +381,18 @@ int amqp_send_frame(amqp_connection_state_t state,
   separate_body = inner_send_frame(state, frame, &encoded, &payload_len);
   switch (separate_body) {
     case 0:
-      AMQP_CHECK_RESULT(write(state->sockfd,
-			      state->outbound_buffer.bytes,
-			      payload_len + (HEADER_SIZE + FOOTER_SIZE)));
+      AMQP_CHECK_RESULT(write_ignore_pipe_signal(state->sockfd,
+			                         state->outbound_buffer.bytes,
+			                         payload_len + (HEADER_SIZE + FOOTER_SIZE)));
       return 0;
 
     case 1:
-      AMQP_CHECK_RESULT(write(state->sockfd, state->outbound_buffer.bytes, HEADER_SIZE));
-      AMQP_CHECK_RESULT(write(state->sockfd, encoded.bytes, payload_len));
+      AMQP_CHECK_RESULT(write_ignore_pipe_signal(state->sockfd, state->outbound_buffer.bytes, HEADER_SIZE));
+      AMQP_CHECK_RESULT(write_ignore_pipe_signal(state->sockfd, encoded.bytes, payload_len));
       {
 	unsigned char frame_end_byte = AMQP_FRAME_END;
 	assert(FOOTER_SIZE == 1);
-	AMQP_CHECK_RESULT(write(state->sockfd, &frame_end_byte, FOOTER_SIZE));
+	AMQP_CHECK_RESULT(write_ignore_pipe_signal(state->sockfd, &frame_end_byte, FOOTER_SIZE));
       }
       return 0;
 

--- a/amqp_private.h
+++ b/amqp_private.h
@@ -132,6 +132,11 @@ extern int amqp_encode_table(amqp_bytes_t encoded,
     _result;					\
   })
 
+/* Writing to pipes normally causes SIGPIPE if the other end has closed.
+   This one doesn't. See more documentation in the implementation in
+   amqp_socket.c */
+ssize_t write_ignore_pipe_signal(int fd, const void *buf, size_t count);
+
 #ifndef NDEBUG
 extern void amqp_dump(void const *buffer, size_t len);
 #else


### PR DESCRIPTION
This is a fix for [Bug #79411 for Net--RabbitMQ: Connect with invalid password exits](https://rt.cpan.org/Public/Bug/Display.html?id=79411)

The problem was that write was called on closed sockets. That caused
SIGPIPE signals that weren't handled.

It is fixed by introducing write_ignore_pipe_signal() that sets up a
short-lived signal handler SIGPIPE that simply ignores the signal
while write() is called.

write_ignore_pipe_signal() is now called everywhere that write() used to
be called directly.
