### PR TITLE
Adding heartbeat frames sending on client side

### DIFF
--- a/RabbitMQ.xs
+++ b/RabbitMQ.xs
@@ -101,6 +101,14 @@ int internal_recv(HV *RETVAL, amqp_connection_state_t conn, int piggyback) {
       amqp_maybe_release_buffers(conn);
       result = amqp_simple_wait_frame(conn, &frame);
       if (result <= 0) break;
+      if (frame.frame_type == AMQP_FRAME_HEARTBEAT) {
+        // Well, let's send the heartbeat frame back, shouldn't we?
+        amqp_frame_t hb_resp;
+        hb_resp.frame_type = AMQP_FRAME_HEARTBEAT;
+        hb_resp.channel = 0;
+        amqp_send_frame(conn, &hb_resp);
+        continue;
+      }
       if (frame.frame_type != AMQP_FRAME_METHOD) continue;
       if (frame.payload.method.id != AMQP_BASIC_DELIVER_METHOD) continue;
       d = (amqp_basic_deliver_t *) frame.payload.method.decoded;
@@ -112,7 +120,13 @@ int internal_recv(HV *RETVAL, amqp_connection_state_t conn, int piggyback) {
     }
 
     result = amqp_simple_wait_frame(conn, &frame);
-    if (frame.frame_type == AMQP_FRAME_HEARTBEAT) continue;
+    if (frame.frame_type == AMQP_FRAME_HEARTBEAT) {
+      amqp_frame_t hb_resp;
+      hb_resp.frame_type = AMQP_FRAME_HEARTBEAT;
+      hb_resp.channel = 0;
+      amqp_send_frame(conn, &hb_resp);
+      continue;
+    }
     if (result <= 0) break;
 
     if (frame.frame_type != AMQP_FRAME_HEADER)


### PR DESCRIPTION
Recover merged but missing commit that makes client send a heartbeat back whenever it receives one.

The original commit is discussed at https://github.com/omniti-labs/Net--RabbitMQ/pull/16. It seems that the pull request was approved but did not find its way into master.
