### PR TITLE
Variable::Magic is (again) optional in tests

### DIFF
--- a/t/013_headers.t
+++ b/t/013_headers.t
@@ -87,6 +87,9 @@ is( $@, '', 'recv from blessed header values' );
 is_deeply( $msg->{props}{headers}, $headers, "Received blessed headers" );
 
 
+SKIP: {
+skip "Variable::Magic not available", 3
+    unless eval "use Variable::Magic qw(wizard cast); 1";
 
 my $wizard = wizard(
 	set => sub { },
@@ -108,4 +111,5 @@ SKIP: {
 	is( $@, '', 'recv from magic header values' );
 
 	is_deeply( $msg->{props}{headers}, $headers, "Received magic headers" );
+}
 }


### PR DESCRIPTION
Change is without proper indentation, to make diffs small.
